### PR TITLE
Fix smallblurb wrapping around preceding lists

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -109,6 +109,7 @@ a:visited { color: #649; }
 .indexmodule .smallblurb {
     font-size: x-small;
     margin-left: 130px;
+    clear: both;
 }
 
 .indexmodule input[type="text"] { width: 20em; margin-left: 2px; }


### PR DESCRIPTION
When a smallblurb paragraph follows a list, on Epiphany (the standard browser on the Raspberry Pi), the smallblurb wraps on the right hand side of the list. This wrapping is only a few characters wide and extremely ugly. Putting "clear: both;" into smallblurb forces the smallblurb paragraph out of the margin of the list.